### PR TITLE
Fix Figma SVG import parameters

### DIFF
--- a/pages/api/import-figma.ts
+++ b/pages/api/import-figma.ts
@@ -158,7 +158,7 @@ export default async function handler(
     const exportTimeoutId = setTimeout(() => exportController.abort(), 20000);
 
     const exportResponse = await fetch(
-      `https://api.figma.com/v1/images/${cleanFileKey}?ids=${nodeToExport}&format=svg&use_absolute_bounds=true`,
+      `https://api.figma.com/v1/images/${cleanFileKey}?ids=${nodeToExport}&format=svg&use_absolute_bounds=true&svg_include_id=true&svg_outline_text=false`,
       {
         headers: {
           'X-Figma-Token': process.env.FIGMA_API_KEY!


### PR DESCRIPTION
## Summary
- add `svg_include_id` and disable outlining text when importing from Figma

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npx tsc` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_683f40682fa083328a0e6e8eeed33de0