### PR TITLE
Fix tspan replacement in SVG processor

### DIFF
--- a/lib/svg-processor.ts
+++ b/lib/svg-processor.ts
@@ -55,10 +55,12 @@ export class SVGProcessor {
         console.log(`Processing ${fieldName} -> ${nodeIdentifier}: "${stringValue}"`);
 
         // Simple text replacement patterns
+        const escapedId = nodeIdentifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const patterns = [
-          new RegExp(`(<text[^>]*id="[^"]*${nodeIdentifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^"]*"[^>]*>)([^<]*)(</text>)`, 'gi'),
-          new RegExp(`(<text[^>]*id="${nodeIdentifier}"[^>]*>)([^<]*)(</text>)`, 'gi'),
-          new RegExp(`(<tspan[^>]*>)([^<]*)(</tspan>)`, 'gi')
+          new RegExp(`(<text[^>]*id="[^\"]*${escapedId}[^\"]*"[^>]*>)([^<]*)(</text>)`, 'gi'),
+          new RegExp(`(<text[^>]*id="${escapedId}"[^>]*>)([^<]*)(</text>)`, 'gi'),
+          new RegExp(`(<tspan[^>]*id="[^\"]*${escapedId}[^\"]*"[^>]*>)([^<]*)(</tspan>)`, 'gi'),
+          new RegExp(`(<tspan[^>]*id="${escapedId}"[^>]*>)([^<]*)(</tspan>)`, 'gi')
         ];
 
         let replaced = false;


### PR DESCRIPTION
## Summary
- avoid replacing all `<tspan>` elements when substituting placeholders

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3fffa60c83329c88fd992bfc00f1